### PR TITLE
CS310 HW3: Page Frame Allocator Implementation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,8 @@ SDIR = src
 OBJS = \
 	kernel_main.o \
 	rprintf.o \
-	interrupt.o
+	interrupt.o \
+	page.o
 # Make sure to keep a blank line here after OBJS list
 
 OBJ = $(patsubst %,$(ODIR)/%,$(OBJS))
@@ -35,6 +36,9 @@ $(ODIR)/rprintf.o: rprintf.c
 	$(CC) $(CFLAGS) -c -g -o $@ $^
 
 $(ODIR)/interrupt.o: interrupt.c
+	$(CC) $(CFLAGS) -c -g -o $@ $^
+	
+$(ODIR)/page.o: page.c
 	$(CC) $(CFLAGS) -c -g -o $@ $^
 
 all: bin rootfs.img

--- a/page.c
+++ b/page.c
@@ -1,0 +1,80 @@
+#include "page.h"
+#include <stddef.h>
+
+struct ppage physical_page_array[128];
+
+struct ppage *free_physical_pages = NULL;
+
+void init_pfa_list(void) {
+    for (int i = 0; i < 128; i++) {
+        physical_page_array[i].physical_addr = (void *)(i * 0x200000);  
+        
+        if (i < 127) {
+            physical_page_array[i].next = &physical_page_array[i + 1];
+        } else {
+            physical_page_array[i].next = NULL;  
+        }
+        
+        if (i > 0) {
+            physical_page_array[i].prev = &physical_page_array[i - 1];
+        } else {
+            physical_page_array[i].prev = NULL; 
+        }
+    }
+    
+    free_physical_pages = &physical_page_array[0];
+}
+
+struct ppage *allocate_physical_pages(unsigned int npages) {
+    if (free_physical_pages == NULL || npages == 0) {
+        return NULL;
+    }
+    
+    struct ppage *allocated_list = free_physical_pages;
+    
+    struct ppage *current = free_physical_pages;
+    unsigned int count = 0;
+    
+    while (current != NULL && count < npages - 1) {
+        current = current->next;
+        count++;
+    }
+    
+    if (current == NULL || count < npages - 1) {
+        return NULL;
+    }
+    
+    struct ppage *new_free_head = current->next;
+    
+    current->next = NULL;
+    
+    free_physical_pages = new_free_head;
+    
+    if (new_free_head != NULL) {
+        new_free_head->prev = NULL;
+    }
+    
+    allocated_list->prev = NULL;
+    
+    return allocated_list;
+}
+
+void free_physical_pages_list(struct ppage *ppage_list) {
+    if (ppage_list == NULL) {
+        return;
+    }
+    
+    struct ppage *current = ppage_list;
+    while (current->next != NULL) {
+        current = current->next;
+    }
+    
+    current->next = free_physical_pages;
+    
+    if (free_physical_pages != NULL) {
+        free_physical_pages->prev = current;
+    }
+    
+    free_physical_pages = ppage_list;
+    free_physical_pages->prev = NULL;
+}

--- a/page.h
+++ b/page.h
@@ -1,0 +1,18 @@
+#ifndef __PAGE_H__
+#define __PAGE_H__
+
+struct ppage {
+    struct ppage *next;
+    struct ppage *prev;
+    void *physical_addr;
+};
+
+// Global pointer to free physical pages list
+extern struct ppage *free_physical_pages;
+
+// Function declarations
+void init_pfa_list(void);
+struct ppage *allocate_physical_pages(unsigned int npages);
+void free_physical_pages_list(struct ppage *ppage_list);
+
+#endif

--- a/src/kernel_main.c
+++ b/src/kernel_main.c
@@ -3,7 +3,8 @@
 const unsigned int multiboot_header[] __attribute__((section(".multiboot"))) = {MULTIBOOT2_HEADER_MAGIC, 0, 16, -(16+MULTIBOOT2_HEADER_MAGIC), 0, 12};
 
 #include "../rprintf.h"
-#include "../interrupt.h"  // Add this for interrupt functions
+#include "../interrupt.h"
+#include "../page.h"
 
 int putc(int data) {
     // Video memory starts at 0xB8000
@@ -59,9 +60,22 @@ void main() {
     asm("sti");   // Enable interrupts
     
     // Print welcome message
-    esp_printf(putc_wrapper, "CS310 Homework 2: Keyboard Interrupts\r\n");
+    esp_printf(putc_wrapper, "CS310 Homework 3: Page Frame Allocator\r\n");
     esp_printf(putc_wrapper, "Interrupts enabled. Type to test keyboard input:\r\n");
     esp_printf(putc_wrapper, "\r\n");
+    
+ 
+	esp_printf(putc_wrapper, "About to call init_pfa_list\r\n");
+	init_pfa_list();
+	esp_printf(putc_wrapper, "Page frame allocator initialized\r\n");
+    
+    struct ppage *pages = allocate_physical_pages(10);
+if (pages != NULL) {
+    esp_printf(putc_wrapper, "Allocated 10 pages successfully\r\n");
+    free_physical_pages_list(pages);
+    esp_printf(putc_wrapper, "Freed 10 pages\r\n");
+}
+esp_printf(putc_wrapper, "\r\n");
     
     // Infinite loop - wait for keyboard interrupts
     while(1) {


### PR DESCRIPTION
Implemented page frame allocator for CS310 HW3

Created page.c and page.h with a doubly-linked list structure
Tested with 10-page allocation
Implemented allocate_physical_pages() to allocate pages from list
Implemented free_physical_pages_list() to return pages to list